### PR TITLE
Convert milliseconds to seconds for iOS.

### DIFF
--- a/ios/Accelerometer.m
+++ b/ios/Accelerometer.m
@@ -40,7 +40,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(setUpdateInterval:(double) interval) {
     NSLog(@"setUpdateInterval: %f", interval);
-    double intervalInSeconds = interval * 1000;
+    double intervalInSeconds = interval / 1000;
 
     [self->_motionManager setAccelerometerUpdateInterval:intervalInSeconds];
 }
@@ -72,7 +72,7 @@ RCT_EXPORT_METHOD(startUpdates) {
     NSLog(@"startUpdates");
     [self->_motionManager startAccelerometerUpdates];
 
-    /* Receive the ccelerometer data on this block */
+    /* Receive the accelerometer data on this block */
     [self->_motionManager startAccelerometerUpdatesToQueue:[NSOperationQueue mainQueue]
                                                withHandler:^(CMAccelerometerData *accelerometerData, NSError *error)
      {

--- a/ios/Gyroscope.m
+++ b/ios/Gyroscope.m
@@ -37,7 +37,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(setUpdateInterval:(double) interval) {
     NSLog(@"setGyroUpdateInterval: %f", interval);
-    double intervalInSeconds = interval * 1000;
+    double intervalInSeconds = interval / 1000;
 
     [self->_motionManager setGyroUpdateInterval:intervalInSeconds];
 }


### PR DESCRIPTION
Fixed the conversion from ms to s, related to https://github.com/react-native-sensors/react-native-sensors/issues/2

Checked on physical iPhone SE with example code that updates are now appearing at expected intervals.