### PR TITLE
Fix export named module (as in examples)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 import Sensors from './src/sensors';
 import decorator from './src/decorator';
 
+export const { Accelerometer, Gyroscope, Magnetometer } = {...Sensors};
+export {decorator};
+
 export default {
   ...Sensors,
   decorator,


### PR DESCRIPTION
Hi !

I had an issue when I tried your example.
The modules were exported by `default` and this is why I wasn't able to access to them.

It's my first pull request so I hope nothing is wrong.

Thanks for your work on this lib,

Julien