### PR TITLE
Update to use prop-types instead of React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "",
   "peerDependencies": {
     "react-native": ">=0.39.0",
-    "prop-types": "^15.6.0",
+    "prop-types": "^15.6.0"
   },
   "dependencies": {
     "rxjs": "^5.0.2"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "author": "",
   "license": "",
   "peerDependencies": {
-    "react-native": ">=0.39.0"
+    "react-native": ">=0.39.0",
+    "prop-types": "^15.6.0",
   },
   "dependencies": {
     "rxjs": "^5.0.2"

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -1,21 +1,22 @@
 import React from 'react';
+import PropTypes from 'prop-types'
 import Sensors from './sensors';
 
 const AVAILABLE_SENSORS = ['Accelerometer', 'Gyroscope'];
-const optionsType = React.PropTypes.shape({
-  updateInterval: React.PropTypes.number,
+const optionsType = PropTypes.shape({
+  updateInterval: PropTypes.number,
 });
 
 class SensorWrapper extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node.isRequired,
-    sensors: React.PropTypes.shape({
-      Accelerometer: React.PropTypes.oneOfType([
-        React.PropTypes.bool,
+    children: PropTypes.node.isRequired,
+    sensors: PropTypes.shape({
+      Accelerometer: PropTypes.oneOfType([
+        PropTypes.bool,
         optionsType,
       ]),
-      Gyroscope: React.PropTypes.oneOfType([
-        React.PropTypes.bool,
+      Gyroscope: PropTypes.oneOfType([
+        PropTypes.bool,
         optionsType,
       ]),
     }),


### PR DESCRIPTION
This fixes issue with deprecated React.PropTypes in issue #31 