### PR TITLE
Fix import issue

### DIFF
--- a/src/sensors.js
+++ b/src/sensors.js
@@ -1,5 +1,5 @@
 import { NativeModules, DeviceEventEmitter } from 'react-native';
-import Rx from 'rxjs/Rx';
+import * as Rx from 'rxjs/Rx';
 const { Gyroscope: GyroNative, Accelerometer: AccNative } = NativeModules;
 
 const handle = {


### PR DESCRIPTION
I tried installing react-native-sensors from scratch today, however it doesn't work due to a bug with rxjs. This is the suggested fix. I can confirm it fixes the problem.

See https://github.com/ReactiveX/rxjs/issues/3155