### PR TITLE
Android: Fix Gyroscope startUpdates native API

### DIFF
--- a/android/src/main/java/com/sensors/Gyroscope.java
+++ b/android/src/main/java/com/sensors/Gyroscope.java
@@ -51,6 +51,7 @@ public class Gyroscope extends ReactContextBaseJavaModule implements SensorEvent
 
   @ReactMethod
   public void startUpdates(Promise promise) {
+    promise.resolve(null);
     // Milisecond to Mikrosecond conversion
     sensorManager.registerListener(this, sensor, this.interval * 1000);
   }


### PR DESCRIPTION
Hi guys! Thank you for the package.

There's one problem with Gyroscope on Android introduced by recent commits: the observable callback is never called, so basically it doesn't work. I use the following workaround for now:
```javascript
DeviceEventEmitter.addListener('Gyroscope', d => { console.log(d); });
```
The culprit is `startUpdates` method. Actually, promises are kind of pointless here (and in Accelerometer code as well), but it's just a quick fix. I'd be great if you release the next major release with appropriate fixes on npm soon.