### PR TITLE
Add linking failure message

### DIFF
--- a/src/rnsensors.js
+++ b/src/rnsensors.js
@@ -1,6 +1,10 @@
 import { NativeModules, DeviceEventEmitter } from "react-native";
 const { Gyroscope: GyroNative, Accelerometer: AccNative } = NativeModules;
 
+if (!GyroNative || !AccNative) {
+	throw new Error("Native modules for sensors not available. Did react-native link run successfully?");
+}
+
 const handle = {
 	Accelerometer: AccNative,
 	Gyroscope: GyroNative

--- a/src/rnsensors.js
+++ b/src/rnsensors.js
@@ -1,7 +1,7 @@
 import { NativeModules, DeviceEventEmitter } from "react-native";
 const { Gyroscope: GyroNative, Accelerometer: AccNative } = NativeModules;
 
-if (!GyroNative || !AccNative) {
+if (!GyroNative && !AccNative) {
 	throw new Error("Native modules for sensors not available. Did react-native link run successfully?");
 }
 


### PR DESCRIPTION
Add error message for when linking has failed.

Previously: TypeError: undefined is not an object (evaluating 'api.setUpdateInterval')
After: Native modules for sensors not available. Did react-native link run successfully?