### PR TITLE
Fix Simulator Crashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Add the following to your Podfile and run `$ pod install`:
       compile project(':react-native-sensors')
     ```
 
+## Running on Simulator
+
+Currently, both iOS and Android simulators offer no support for sensors. In order to retrieve any sensor output, you **must develop on a real device**.
+
 ## Usage
 
 ### Sensor API

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Add the following to your Podfile and run `$ pod install`:
 
 iOS simulators currently have **no support** for sensors. In order to retrieve any sensor output, you **must develop on a real device**.
 
-Android simulators offer support for some sensors.
+Android simulators offer support for some sensors. [This article](https://developer.android.com/studio/run/emulator#extended) documents how to use them (under the "Virtual Sensors" section.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ Add the following to your Podfile and run `$ pod install`:
 
 ## Running on Simulator
 
-Currently, both iOS and Android simulators offer no support for sensors. In order to retrieve any sensor output, you **must develop on a real device**.
+iOS simulators currently have **no support** for sensors. In order to retrieve any sensor output, you **must develop on a real device**.
+
+Android simulators offer support for some sensors.
 
 ## Usage
 

--- a/ios/Accelerometer.m
+++ b/ios/Accelerometer.m
@@ -37,12 +37,12 @@ RCT_REMAP_METHOD(isAvailable,
         {
             resolve(@YES);
         } else {
-            reject(@"-1", @"Acceletometer is not active", [[NSError alloc] init]);
+            reject(@"-1", @"Acceletometer is not active", nil);
         }
     }
     else
     {
-        reject(@"-1", @"Acceletometer is not available", [[NSError alloc] init]);
+        reject(@"-1", @"Acceletometer is not available", nil);
     }
 }
 

--- a/ios/Gyroscope.m
+++ b/ios/Gyroscope.m
@@ -35,12 +35,12 @@ RCT_REMAP_METHOD(isAvailable,
         {
             resolve(@YES);
         } else {
-            reject(@"-1", @"Gyroscope is not active", [[NSError alloc] init]);
+            reject(@"-1", @"Gyroscope is not active", nil);
         }
     }
     else
     {
-        reject(@"-1", @"Gyroscope is not available", [[NSError alloc] init]);
+        reject(@"-1", @"Gyroscope is not available", nil);
     }
 }
 

--- a/ios/Magnetometer.m
+++ b/ios/Magnetometer.m
@@ -38,12 +38,12 @@ RCT_REMAP_METHOD(isAvailable,
         {
             resolve(@YES);
         } else {
-            reject(@"-1", @"Magnetometer is not active", [[NSError alloc] init]);
+            reject(@"-1", @"Magnetometer is not active", nil);
         }
     }
     else
     {
-        reject(@"-1", @"Magnetometer is not available", [[NSError alloc] init]);
+        reject(@"-1", @"Magnetometer is not available", nil);
     }
 }
 

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { Observable } from 'rxjs';
 import Sensors from "./sensors";
 
 const AVAILABLE_SENSORS = ["Accelerometer", "Gyroscope", "Magnetometer"];
@@ -58,7 +59,11 @@ class SensorWrapper extends React.Component {
   }
 
   componentWillUnmount() {
-    this.state._observables.forEach(observable => observable.stop());
+    this.state._observables.forEach((observable) => {
+      if (observable instanceof Observable) {
+        observable.stop();
+      }
+    });
   }
 
   render() {

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Observable } from 'rxjs';
+import { Observable } from "rxjs";
 import Sensors from "./sensors";
 
 const AVAILABLE_SENSORS = ["Accelerometer", "Gyroscope", "Magnetometer"];
@@ -59,7 +59,7 @@ class SensorWrapper extends React.Component {
   }
 
   componentWillUnmount() {
-    this.state._observables.forEach((observable) => {
+    this.state._observables.forEach(observable => {
       if (observable instanceof Observable) {
         observable.stop();
       }


### PR DESCRIPTION
To resolve #131, set all instances of `[[NSError alloc] init]` to `nil` to prevent crashing on the simulator. Simulator will still not provide sensor data, but it allows continued development on the platform.

In addition, added a disclaimer in `README.md` to note the quirks of running on any simulator.