### PR TITLE
Do not convert errors to return values.

### DIFF
--- a/src/sensors.js
+++ b/src/sensors.js
@@ -28,9 +28,6 @@ function createSensorMonitorCreator(sensorType) {
         };
 
         return observable;
-      })
-      .catch(error => {
-        return error;
       });
   }
 


### PR DESCRIPTION
Usage in the docs:

```javascript
new Accelerometer({
  updateInterval: 400 // defaults to 100ms
})
  .then(observable => {
  })
  .catch(error => {
    console.log("The sensor is not available");
  });
```

This is how it should be.

However, currently, catch is never executed. Instead, the error is returned in the `then` clause. This is the fix.