### PR TITLE
Fixed spelling error

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -15,7 +15,7 @@ import {
 } from "react-native-sensors";
 import { map, filter } from "rxjs/operators";
 
-setUpdateIntervalForType(SensorTypes.Accelerometer, 400); // defaults to 100ms
+setUpdateIntervalForType(SensorTypes.accelerometer, 400); // defaults to 100ms
 
 const subscription = accelerometer
   .pipe(map(({ x, y, z }) => x + y + z), filter(speed => speed > 20))


### PR DESCRIPTION
The documentation here https://react-native-sensors.github.io/docs/Usage.html states:
`setUpdateIntervalForType(SensorTypes.Accelerometer, 400); // defaults to 100ms`

If you spell Accelerometer with a capital A the app will throw an error.
This is the correct spelling:
`setUpdateIntervalForType(SensorTypes.accelerometer, 400); // defaults to 100ms`