### PR TITLE
Fix barometer on iOS.

### DIFF
--- a/ios/Barometer.m
+++ b/ios/Barometer.m
@@ -37,14 +37,9 @@ RCT_REMAP_METHOD(isAvailable,
 - (void) isAvailableWithResolver:(RCTPromiseResolveBlock) resolve
                         rejecter:(RCTPromiseRejectBlock) reject {
 
-    if (![CMAltimeter isRelativeAltitudeAvailable]) 
+    if ([CMAltimeter isRelativeAltitudeAvailable]) 
     {
-        if([CMPedometer authorizationStatus] == CMAuthorizationStatusAuthorized)
-        {
-            resolve(@YES);
-        } else {
-            reject(@"-1", @"Barometer is not authorized", nil);
-        }
+        resolve(@YES);
     }
     else
     {

--- a/ios/Barometer.m
+++ b/ios/Barometer.m
@@ -66,7 +66,7 @@ RCT_EXPORT_METHOD(startUpdates) {
         
         if (altitudeData) {
             [self.bridge.eventDispatcher sendDeviceEventWithName:@"Barometer" body:@{
-                @"pressure" : altitudeData.pressure
+                @"pressure" : @(altitudeData.pressure.doubleValue * 10.0)
             }];
         }
         


### PR DESCRIPTION
There seems to be a logic error in the availability check for the barometer on iOS. Also, the barometer seems to always be available, so I removed the `CMPedometer` check as well.