### PR TITLE
refactor(project): export isAvailable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import sensors from "./src/sensors";
-export { setUpdateInterval as setUpdateIntervalForType } from "./src/rnsensors";
+export { isAvailable, setUpdateInterval as setUpdateIntervalForType } from "./src/rnsensors";
 
 export const SensorTypes = {
   accelerometer: "accelerometer",


### PR DESCRIPTION
Exporting isAvailable allows you to at least implement a workaround for the iOS simulator without using the callback for `error`.