### PR TITLE
[Typescript] Fix 'setsetUpdateIntervalForType' params & sensors type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,17 @@
 declare module "react-native-sensors" {
-  export const SensorTypes: {
+  import { Observable } from "rxjs";
+
+  type Sensors = {
     accelerometer: "accelerometer";
     gyroscope: "gyroscope";
     magnetometer: "magnetometer";
     barometer: "barometer";
   };
 
+  export const SensorTypes: Sensors;
+
   export const setUpdateIntervalForType: (
-    type: "accelerometer" | "gyroscope" | "magnetometer" | "barometer",
+    type: keyof Sensors,
     updateInterval: number
   ) => void;
 
@@ -18,34 +22,25 @@ declare module "react-native-sensors" {
     timestamp: string;
   }
 
-  import { Observable, Unsubscribable } from "rxjs";
-  export { Unsubscribable };
-  export type RNSensorObservable = Observable<SensorData>;
-
-  export interface RNSensor {
-    subscribe: (
-      observer: ({ x, y, z, timestamp }: SensorData) => SensorData
-    ) => Unsubscribable;
+  interface BarometerData {
+    pressure: number;
   }
+
+  type SensorsBase = {
+    accelerometer: Observable<SensorData>;
+    gyroscope: Observable<SensorData>;
+    magnetometer: Observable<SensorData>;
+    barometer: Observable<BarometerData>;
+  };
 
   export const {
     accelerometer,
     gyroscope,
     magnetometer,
     barometer
-  }: {
-    accelerometer: RNSensor;
-    gyroscope: RNSensor;
-    magnetometer: RNSensor;
-    barometer: RNSensor;
-  };
+  }: SensorsBase;
 
-  const sensors: {
-    accelerometer: RNSensor;
-    gyroscope: RNSensor;
-    magnetometer: RNSensor;
-    barometer: RNSensor;
-  };
+  const sensors: SensorsBase;
 
   export default sensors;
 }


### PR DESCRIPTION
I have updated the following types

1. `setUpdateIntervalForType` -> The current implementation was not checking whether `type` was one of sensors in `SensorsTypes` or not, now it does.
2. `sensors` -> the old `RNSensor` didn't match the return of a real observable, so I replaced it with the real type.
3. The barometer sensor was returning the same data as the other sensors and that was wrong, so I created a custom type for that sensor.