### PR TITLE
Fix to allow installation on >=RN0.60.0

### DIFF
--- a/RNSensors.podspec
+++ b/RNSensors.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license             = package['license']
   s.author              = package['author']
   s.source              = { :git => "https://github.com/react-native-sensors/react-native-sensors.git" }
-  s.platform            = :ios, "7.0"
+  s.platform            = :ios, "8.0"
   s.source_files        = "ios/*.{h,m}"
   s.preserve_paths      = "*.js"
   s.dependency 'React'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ android {
     compileSdkVersion safeExtGet('compileSdkVersion', 23)
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"
@@ -24,4 +24,6 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
+    implementation 'androidx.annotation:annotation:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
 }

--- a/android/src/main/java/com/sensors/Accelerometer.java
+++ b/android/src/main/java/com/sensors/Accelerometer.java
@@ -6,7 +6,7 @@ import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.util.Log;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;

--- a/android/src/main/java/com/sensors/Barometer.java
+++ b/android/src/main/java/com/sensors/Barometer.java
@@ -6,7 +6,7 @@ import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.util.Log;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;

--- a/android/src/main/java/com/sensors/Gyroscope.java
+++ b/android/src/main/java/com/sensors/Gyroscope.java
@@ -6,7 +6,7 @@ import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.util.Log;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;

--- a/android/src/main/java/com/sensors/Magnetometer.java
+++ b/android/src/main/java/com/sensors/Magnetometer.java
@@ -6,7 +6,7 @@ import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.util.Log;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -10,6 +10,22 @@ sidebar_label: Installation
 
 ### Automatic installation
 
+#### RN >=0.60.0
+CocoaPods is not the recommended method to adding libraries to react-native.
+
+Add the following to your Podfile and run `$ pod install`:
+
+`pod 'RNSensors', :path => '../node_modules/react-native-sensors'`
+
+then from your project directory run:
+
+`$ cd ios`
+`pod install`
+
+DO NOT RUN `react-native link react-native-sensors` this is no longer required with RN 0.60 or above.
+
+#### RN <=0.59.10
+
 `$ react-native link react-native-sensors`
 
 Option: With CocoaPods (iOS only)


### PR DESCRIPTION
fix: allow project to be used with RN 0.60.0

Also providing updated install instructions

BREAKING CHANGE: You need to update React Native to work with this version