### PR TITLE
fix(iOS): Changed iOS to use RCTEventEmitter when sending messages to RN

### DIFF
--- a/ios/Accelerometer.h
+++ b/ios/Accelerometer.h
@@ -2,8 +2,9 @@
 
 #import <React/RCTBridgeModule.h>
 #import <CoreMotion/CoreMotion.h>
+#import <React/RCTEventEmitter.h>
 
-@interface Accelerometer : NSObject <RCTBridgeModule> {
+@interface Accelerometer : RCTEventEmitter <RCTBridgeModule> {
     CMMotionManager *_motionManager;
 }
 

--- a/ios/Accelerometer.m
+++ b/ios/Accelerometer.m
@@ -95,7 +95,7 @@ RCT_EXPORT_METHOD(startUpdates) {
          double timestamp = accelerometerData.timestamp;
          NSLog(@"startAccelerometerUpdates: %f, %f, %f, %f", x, y, z, timestamp);
 
-         [self.bridge.eventDispatcher sendDeviceEventWithName:@"Accelerometer" body:@{
+         [self sendEventWithName:@"Accelerometer" body:@{
                                                                                    @"x" : [NSNumber numberWithDouble:x],
                                                                                    @"y" : [NSNumber numberWithDouble:y],
                                                                                    @"z" : [NSNumber numberWithDouble:z],

--- a/ios/Barometer.h
+++ b/ios/Barometer.h
@@ -2,8 +2,9 @@
 
 #import <React/RCTBridgeModule.h>
 #import <CoreMotion/CoreMotion.h>
+#import <React/RCTEventEmitter.h>
 
-@interface Barometer : NSObject <RCTBridgeModule> {
+@interface Barometer : RCTEventEmitter <RCTBridgeModule> {
     CMAltimeter *_altimeter;
 }
 

--- a/ios/Barometer.m
+++ b/ios/Barometer.m
@@ -65,7 +65,7 @@ RCT_EXPORT_METHOD(startUpdates) {
         }
         
         if (altitudeData) {
-            [self.bridge.eventDispatcher sendDeviceEventWithName:@"Barometer" body:@{
+            [self sendEventWithName:@"Barometer" body:@{
                 @"pressure" : @(altitudeData.pressure.doubleValue * 10.0)
             }];
         }

--- a/ios/Gyroscope.h
+++ b/ios/Gyroscope.h
@@ -2,8 +2,9 @@
 
 #import <React/RCTBridgeModule.h>
 #import <CoreMotion/CoreMotion.h>
+#import <React/RCTEventEmitter.h>
 
-@interface Gyroscope : NSObject<RCTBridgeModule> {
+@interface Gyroscope : RCTEventEmitter <RCTBridgeModule> {
     CMMotionManager *_motionManager;
 }
 

--- a/ios/Gyroscope.m
+++ b/ios/Gyroscope.m
@@ -93,7 +93,7 @@ RCT_EXPORT_METHOD(startUpdates) {
          double timestamp = gyroData.timestamp;
          NSLog(@"startUpdates: %f, %f, %f, %f", x, y, z, timestamp);
 
-         [self.bridge.eventDispatcher sendDeviceEventWithName:@"Gyroscope" body:@{
+         [self sendEventWithName:@"Gyroscope" body:@{
                                                                                      @"x" : [NSNumber numberWithDouble:x],
                                                                                      @"y" : [NSNumber numberWithDouble:y],
                                                                                      @"z" : [NSNumber numberWithDouble:z],

--- a/ios/Magnetometer.h
+++ b/ios/Magnetometer.h
@@ -2,8 +2,9 @@
 
 #import <React/RCTBridgeModule.h>
 #import <CoreMotion/CoreMotion.h>
+#import <React/RCTEventEmitter.h>
 
-@interface Magnetometer : NSObject <RCTBridgeModule> {
+@interface Magnetometer : RCTEventEmitter <RCTBridgeModule> {
     CMMotionManager *_motionManager;
 }
 

--- a/ios/Magnetometer.m
+++ b/ios/Magnetometer.m
@@ -96,7 +96,7 @@ RCT_EXPORT_METHOD(startUpdates) {
          double timestamp = magnetometerData.timestamp;
          NSLog(@"startMagnetometerUpdates: %f, %f, %f, %f", x, y, z, timestamp);
 
-         [self.bridge.eventDispatcher sendDeviceEventWithName:@"Magnetometer" body:@{
+         [self sendEventWithName:@"Magnetometer" body:@{
                                                                                    @"x" : [NSNumber numberWithDouble:x],
                                                                                    @"y" : [NSNumber numberWithDouble:y],
                                                                                    @"z" : [NSNumber numberWithDouble:z],


### PR DESCRIPTION
I am not a iOS developer so feel free to tell me if i did anything wrong. 
This fixes #266 .
sendDeviceEventWithName is deprecated and probably has a memory leak.
What i did was changing it to use RCTEventEmitter sendEventWithName.