### PR TITLE
feat(typescript): Export SensorData and BarometerData interfaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,14 +15,14 @@ declare module "react-native-sensors" {
     updateInterval: number
   ) => void;
 
-  interface SensorData {
+  export interface SensorData {
     x: number;
     y: number;
     z: number;
     timestamp: string;
   }
 
-  interface BarometerData {
+  export interface BarometerData {
     pressure: number;
   }
 


### PR DESCRIPTION
Exporting the interfaces allows them to be used when with a function that is not anonymous (otherwise stricter compiler settings may throw errors or warnings).

Example:
```
  // Inside react component

  private subscription: Subscription;
  private onSensorUpdate = (values:SensorData) => {
    // Do something with values
  }
  
  public componentDidMount() {
    this.subscription = magnetometer.subscribe(this.onSensorUpdate);
  }
```