### PR TITLE
Consistent timestamp accross ios/android

### DIFF
--- a/android/src/main/java/com/sensors/Accelerometer.java
+++ b/android/src/main/java/com/sensors/Accelerometer.java
@@ -95,7 +95,7 @@ public class Accelerometer extends ReactContextBaseJavaModule implements SensorE
           map.putDouble("x", sensorEvent.values[0]);
           map.putDouble("y", sensorEvent.values[1]);
           map.putDouble("z", sensorEvent.values[2]);
-          map.putDouble("timestamp", Utils.sensorTimeToTimestampSince1970(sensorEvent.timestamp));
+          map.putDouble("timestamp", Utils.sensorTimestampToEpochMilliseconds(sensorEvent.timestamp));
           sendEvent("Accelerometer", map);
         }
       }

--- a/android/src/main/java/com/sensors/Accelerometer.java
+++ b/android/src/main/java/com/sensors/Accelerometer.java
@@ -58,7 +58,7 @@ public class Accelerometer extends ReactContextBaseJavaModule implements SensorE
 
   @ReactMethod
   public void startUpdates() {
-    // Milisecond to Mikrosecond conversion
+    // Milliseconds to Microseconds conversion
     sensorManager.registerListener(this, sensor, this.interval * 1000);
   }
 
@@ -95,7 +95,7 @@ public class Accelerometer extends ReactContextBaseJavaModule implements SensorE
           map.putDouble("x", sensorEvent.values[0]);
           map.putDouble("y", sensorEvent.values[1]);
           map.putDouble("z", sensorEvent.values[2]);
-          map.putDouble("timestamp", tempMs);
+          map.putDouble("timestamp", Utils.sensorTimeToTimestampSince1970(sensorEvent.timestamp));
           sendEvent("Accelerometer", map);
         }
       }

--- a/android/src/main/java/com/sensors/Barometer.java
+++ b/android/src/main/java/com/sensors/Barometer.java
@@ -93,6 +93,7 @@ public class Barometer extends ReactContextBaseJavaModule implements SensorEvent
 
         if (mySensor.getType() == Sensor.TYPE_PRESSURE) {
           map.putDouble("pressure", sensorEvent.values[0]);
+          map.putDouble("timestamp", Utils.sensorTimeToTimestampSince1970(sensorEvent.timestamp));
           sendEvent("Barometer", map);
         }
       }

--- a/android/src/main/java/com/sensors/Barometer.java
+++ b/android/src/main/java/com/sensors/Barometer.java
@@ -93,7 +93,7 @@ public class Barometer extends ReactContextBaseJavaModule implements SensorEvent
 
         if (mySensor.getType() == Sensor.TYPE_PRESSURE) {
           map.putDouble("pressure", sensorEvent.values[0]);
-          map.putDouble("timestamp", Utils.sensorTimeToTimestampSince1970(sensorEvent.timestamp));
+          map.putDouble("timestamp", Utils.sensorTimestampToEpochMilliseconds(sensorEvent.timestamp));
           sendEvent("Barometer", map);
         }
       }

--- a/android/src/main/java/com/sensors/Gyroscope.java
+++ b/android/src/main/java/com/sensors/Gyroscope.java
@@ -94,7 +94,7 @@ public class Gyroscope extends ReactContextBaseJavaModule implements SensorEvent
           map.putDouble("x", sensorEvent.values[0]);
           map.putDouble("y", sensorEvent.values[1]);
           map.putDouble("z", sensorEvent.values[2]);
-          map.putDouble("timestamp", Utils.sensorTimeToTimestampSince1970(sensorEvent.timestamp));
+          map.putDouble("timestamp", Utils.sensorTimestampToEpochMilliseconds(sensorEvent.timestamp));
           sendEvent("Gyroscope", map);
         }
       }

--- a/android/src/main/java/com/sensors/Gyroscope.java
+++ b/android/src/main/java/com/sensors/Gyroscope.java
@@ -57,7 +57,7 @@ public class Gyroscope extends ReactContextBaseJavaModule implements SensorEvent
 
   @ReactMethod
   public void startUpdates() {
-    // Milisecond to Mikrosecond conversion
+    // Milliseconds to Microseconds conversion
     sensorManager.registerListener(this, sensor, this.interval * 1000);
   }
 
@@ -94,7 +94,7 @@ public class Gyroscope extends ReactContextBaseJavaModule implements SensorEvent
           map.putDouble("x", sensorEvent.values[0]);
           map.putDouble("y", sensorEvent.values[1]);
           map.putDouble("z", sensorEvent.values[2]);
-          map.putDouble("timestamp", (double) System.currentTimeMillis());
+          map.putDouble("timestamp", Utils.sensorTimeToTimestampSince1970(sensorEvent.timestamp));
           sendEvent("Gyroscope", map);
         }
       }

--- a/android/src/main/java/com/sensors/Magnetometer.java
+++ b/android/src/main/java/com/sensors/Magnetometer.java
@@ -57,7 +57,7 @@ public class Magnetometer extends ReactContextBaseJavaModule implements SensorEv
 
   @ReactMethod
   public void startUpdates() {
-    // Milisecond to Mikrosecond conversion
+    // Milliseconds to Microseconds conversion
     sensorManager.registerListener(this, sensor, this.interval * 1000);
   }
 
@@ -91,10 +91,10 @@ public class Magnetometer extends ReactContextBaseJavaModule implements SensorEv
       WritableMap map = arguments.createMap();
 
       if (mySensor.getType() == Sensor.TYPE_MAGNETIC_FIELD) {
-        map.putDouble("x", sensorEvent.values[0]);
-        map.putDouble("y", sensorEvent.values[1]);
-        map.putDouble("z", sensorEvent.values[2]);
-        map.putDouble("timestamp", tempMs);
+          map.putDouble("x", sensorEvent.values[0]);
+          map.putDouble("y", sensorEvent.values[1]);
+          map.putDouble("z", sensorEvent.values[2]);
+          map.putDouble("timestamp", Utils.sensorTimeToTimestampSince1970(sensorEvent.timestamp));
           sendEvent("Magnetometer", map);
         }
       }

--- a/android/src/main/java/com/sensors/Magnetometer.java
+++ b/android/src/main/java/com/sensors/Magnetometer.java
@@ -94,7 +94,7 @@ public class Magnetometer extends ReactContextBaseJavaModule implements SensorEv
           map.putDouble("x", sensorEvent.values[0]);
           map.putDouble("y", sensorEvent.values[1]);
           map.putDouble("z", sensorEvent.values[2]);
-          map.putDouble("timestamp", Utils.sensorTimeToTimestampSince1970(sensorEvent.timestamp));
+          map.putDouble("timestamp", Utils.sensorTimestampToEpochMilliseconds(sensorEvent.timestamp));
           sendEvent("Magnetometer", map);
         }
       }

--- a/android/src/main/java/com/sensors/Utils.java
+++ b/android/src/main/java/com/sensors/Utils.java
@@ -1,10 +1,12 @@
 package com.sensors;
+import java.lang.*;
+import android.os.SystemClock;
 
 public final class Utils {
 
-    public static double sensorTimeToTimestampSince1970(long elapsedTime) {
+    public static double sensorTimestampToEpochMilliseconds(long elapsedTime) {
         // elapsedTime = The time in nanoseconds at which the event happened.
-        return System.currentTimeMillis() + ((elapsedTime-SystemClock.elapsedRealtimeNanos())/1000000L)
+        return System.currentTimeMillis() + ((elapsedTime-SystemClock.elapsedRealtimeNanos())/1000000L);
     }
 
 }

--- a/android/src/main/java/com/sensors/Utils.java
+++ b/android/src/main/java/com/sensors/Utils.java
@@ -1,0 +1,10 @@
+package com.sensors;
+
+public final class Utils {
+
+    public static double sensorTimeToTimestampSince1970(long elapsedTime) {
+        // elapsedTime = The time in nanoseconds at which the event happened.
+        return System.currentTimeMillis() + ((elapsedTime-SystemClock.elapsedRealtimeNanos())/1000000L)
+    }
+
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,14 +15,14 @@ declare module "react-native-sensors" {
     updateInterval: number
   ) => void;
 
-  interface SensorData {
+  export interface SensorData {
     x: number;
     y: number;
     z: number;
     timestamp: string;
   }
 
-  interface BarometerData {
+  export interface BarometerData {
     pressure: number;
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,7 @@ declare module "react-native-sensors" {
 
   export interface BarometerData {
     pressure: number;
+    timestamp: string;
   }
 
   type SensorsBase = {

--- a/ios/Accelerometer.m
+++ b/ios/Accelerometer.m
@@ -90,7 +90,7 @@ RCT_EXPORT_METHOD(getData:(RCTResponseSenderBlock) cb) {
     double x = self->_motionManager.accelerometerData.acceleration.x;
     double y = self->_motionManager.accelerometerData.acceleration.y;
     double z = self->_motionManager.accelerometerData.acceleration.z;
-    double timestamp = [Utils sensorTimeToTimestampSince1970:self->_motionManager.accelerometerData.timestamp];
+    double timestamp = [Utils sensorTimestampToEpochMilliseconds:self->_motionManager.accelerometerData.timestamp];
 
     if (self->logLevel > 0) {
         NSLog(@"getData: %f, %f, %f, %f", x, y, z, timestamp);
@@ -119,7 +119,7 @@ RCT_EXPORT_METHOD(startUpdates) {
          double x = accelerometerData.acceleration.x;
          double y = accelerometerData.acceleration.y;
          double z = accelerometerData.acceleration.z;
-         double timestamp = [Utils sensorTimeToTimestampSince1970:accelerometerData.timestamp];
+         double timestamp = [Utils sensorTimestampToEpochMilliseconds:accelerometerData.timestamp];
 
          if (self->logLevel > 1) {
              NSLog(@"Updated accelerometer values: %f, %f, %f, %f", x, y, z, timestamp);

--- a/ios/Accelerometer.m
+++ b/ios/Accelerometer.m
@@ -4,6 +4,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
 #import "Accelerometer.h"
+#import "Utils.h"
 
 @implementation Accelerometer
 
@@ -89,7 +90,7 @@ RCT_EXPORT_METHOD(getData:(RCTResponseSenderBlock) cb) {
     double x = self->_motionManager.accelerometerData.acceleration.x;
     double y = self->_motionManager.accelerometerData.acceleration.y;
     double z = self->_motionManager.accelerometerData.acceleration.z;
-    double timestamp = self->_motionManager.accelerometerData.timestamp;
+    double timestamp = [Utils sensorTimeToTimestampSince1970:self->_motionManager.accelerometerData.timestamp];
 
     if (self->logLevel > 0) {
         NSLog(@"getData: %f, %f, %f, %f", x, y, z, timestamp);
@@ -118,18 +119,18 @@ RCT_EXPORT_METHOD(startUpdates) {
          double x = accelerometerData.acceleration.x;
          double y = accelerometerData.acceleration.y;
          double z = accelerometerData.acceleration.z;
-         double timestamp = accelerometerData.timestamp;
+         double timestamp = [Utils sensorTimeToTimestampSince1970:accelerometerData.timestamp];
 
          if (self->logLevel > 1) {
              NSLog(@"Updated accelerometer values: %f, %f, %f, %f", x, y, z, timestamp);
          }
 
          [self sendEventWithName:@"Accelerometer" body:@{
-                                                                                   @"x" : [NSNumber numberWithDouble:x],
-                                                                                   @"y" : [NSNumber numberWithDouble:y],
-                                                                                   @"z" : [NSNumber numberWithDouble:z],
-                                                                                   @"timestamp" : [NSNumber numberWithDouble:timestamp]
-                                                                               }];
+                                                           @"x" : [NSNumber numberWithDouble:x],
+                                                           @"y" : [NSNumber numberWithDouble:y],
+                                                           @"z" : [NSNumber numberWithDouble:z],
+                                                           @"timestamp" : [NSNumber numberWithDouble:timestamp]
+                                                       }];
      }];
 
 }

--- a/ios/Barometer.m
+++ b/ios/Barometer.m
@@ -5,6 +5,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
 #import <CoreMotion/CoreMotion.h>
+#import "Utils.h"
 
 @implementation Barometer
 
@@ -82,11 +83,12 @@ RCT_EXPORT_METHOD(startUpdates) {
 
         if (altitudeData) {
             if (self->logLevel > 1) {
-                NSLog(@"Updated altitue value: %f, %f", altitudeData.pressure.doubleValue, altitudeData.timestamp);
+                NSLog(@"Updated altitue value: %f, %f, %f", altitudeData.pressure.doubleValue, altitudeData.timestamp, [Utils sensorTimeToTimestampSince1970:altitudeData.timestamp]);
             }
 
             [self sendEventWithName:@"Barometer" body:@{
-                @"pressure" : @(altitudeData.pressure.doubleValue * 10.0)
+                @"pressure" : @(altitudeData.pressure.doubleValue * 10.0),
+                @"timestamp" : [NSNumber numberWithDouble:[Utils sensorTimeToTimestampSince1970:altitudeData.timestamp]]
             }];
         }
 

--- a/ios/Barometer.m
+++ b/ios/Barometer.m
@@ -83,12 +83,12 @@ RCT_EXPORT_METHOD(startUpdates) {
 
         if (altitudeData) {
             if (self->logLevel > 1) {
-                NSLog(@"Updated altitue value: %f, %f, %f", altitudeData.pressure.doubleValue, altitudeData.timestamp, [Utils sensorTimeToTimestampSince1970:altitudeData.timestamp]);
+                NSLog(@"Updated altitue value: %f, %f, %f", altitudeData.pressure.doubleValue, altitudeData.timestamp, [Utils sensorTimestampToEpochMilliseconds:altitudeData.timestamp]);
             }
 
             [self sendEventWithName:@"Barometer" body:@{
                 @"pressure" : @(altitudeData.pressure.doubleValue * 10.0),
-                @"timestamp" : [NSNumber numberWithDouble:[Utils sensorTimeToTimestampSince1970:altitudeData.timestamp]]
+                @"timestamp" : [NSNumber numberWithDouble:[Utils sensorTimestampToEpochMilliseconds:altitudeData.timestamp]]
             }];
         }
 

--- a/ios/Gyroscope.m
+++ b/ios/Gyroscope.m
@@ -3,6 +3,7 @@
 #import "Gyroscope.h"
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
+#import "Utils.h"
 
 @implementation Gyroscope
 
@@ -87,7 +88,7 @@ RCT_EXPORT_METHOD(getData:(RCTResponseSenderBlock) cb) {
     double x = self->_motionManager.gyroData.rotationRate.x;
     double y = self->_motionManager.gyroData.rotationRate.y;
     double z = self->_motionManager.gyroData.rotationRate.z;
-    double timestamp = self->_motionManager.gyroData.timestamp;
+    double timestamp = [Utils sensorTimeToTimestampSince1970:self->_motionManager.gyroData.timestamp];
 
     if (self->logLevel > 0) {
         NSLog(@"getData: %f, %f, %f, %f", x, y, z, timestamp);
@@ -116,18 +117,18 @@ RCT_EXPORT_METHOD(startUpdates) {
          double x = gyroData.rotationRate.x;
          double y = gyroData.rotationRate.y;
          double z = gyroData.rotationRate.z;
-         double timestamp = gyroData.timestamp;
+         double timestamp = [Utils sensorTimeToTimestampSince1970:gyroData.timestamp];
 
          if (self->logLevel > 1) {
              NSLog(@"Updated gyro values: %f, %f, %f, %f", x, y, z, timestamp);
          }
 
          [self sendEventWithName:@"Gyroscope" body:@{
-                                                                                     @"x" : [NSNumber numberWithDouble:x],
-                                                                                     @"y" : [NSNumber numberWithDouble:y],
-                                                                                     @"z" : [NSNumber numberWithDouble:z],
-                                                                                     @"timestamp" : [NSNumber numberWithDouble:timestamp]
-                                                                                 }];
+                                                         @"x" : [NSNumber numberWithDouble:x],
+                                                         @"y" : [NSNumber numberWithDouble:y],
+                                                         @"z" : [NSNumber numberWithDouble:z],
+                                                         @"timestamp" : [NSNumber numberWithDouble:timestamp]
+                                                     }];
      }];
 
 }

--- a/ios/Gyroscope.m
+++ b/ios/Gyroscope.m
@@ -88,7 +88,7 @@ RCT_EXPORT_METHOD(getData:(RCTResponseSenderBlock) cb) {
     double x = self->_motionManager.gyroData.rotationRate.x;
     double y = self->_motionManager.gyroData.rotationRate.y;
     double z = self->_motionManager.gyroData.rotationRate.z;
-    double timestamp = [Utils sensorTimeToTimestampSince1970:self->_motionManager.gyroData.timestamp];
+    double timestamp = [Utils sensorTimestampToEpochMilliseconds:self->_motionManager.gyroData.timestamp];
 
     if (self->logLevel > 0) {
         NSLog(@"getData: %f, %f, %f, %f", x, y, z, timestamp);
@@ -117,7 +117,7 @@ RCT_EXPORT_METHOD(startUpdates) {
          double x = gyroData.rotationRate.x;
          double y = gyroData.rotationRate.y;
          double z = gyroData.rotationRate.z;
-         double timestamp = [Utils sensorTimeToTimestampSince1970:gyroData.timestamp];
+         double timestamp = [Utils sensorTimestampToEpochMilliseconds:gyroData.timestamp];
 
          if (self->logLevel > 1) {
              NSLog(@"Updated gyro values: %f, %f, %f, %f", x, y, z, timestamp);

--- a/ios/Magnetometer.m
+++ b/ios/Magnetometer.m
@@ -5,6 +5,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
 #import "Magnetometer.h"
+#import "Utils.h"
 
 @implementation Magnetometer
 
@@ -90,7 +91,7 @@ RCT_EXPORT_METHOD(getData:(RCTResponseSenderBlock) cb) {
     double x = self->_motionManager.magnetometerData.magneticField.x;
     double y = self->_motionManager.magnetometerData.magneticField.y;
     double z = self->_motionManager.magnetometerData.magneticField.z;
-    double timestamp = self->_motionManager.magnetometerData.timestamp;
+    double timestamp = [Utils sensorTimeToTimestampSince1970:self->_motionManager.magnetometerData.timestamp];
 
     if (self->logLevel > 0) {
         NSLog(@"getData: %f, %f, %f, %f", x, y, z, timestamp);
@@ -119,18 +120,18 @@ RCT_EXPORT_METHOD(startUpdates) {
          double x = magnetometerData.magneticField.x;
          double y = magnetometerData.magneticField.y;
          double z = magnetometerData.magneticField.z;
-         double timestamp = magnetometerData.timestamp;
+         double timestamp = [Utils sensorTimeToTimestampSince1970:magnetometerData.timestamp];
 
          if (self->logLevel > 1) {
              NSLog(@"Updated magnetometer values: %f, %f, %f, %f", x, y, z, timestamp);
          }
 
          [self sendEventWithName:@"Magnetometer" body:@{
-                                                                                   @"x" : [NSNumber numberWithDouble:x],
-                                                                                   @"y" : [NSNumber numberWithDouble:y],
-                                                                                   @"z" : [NSNumber numberWithDouble:z],
-                                                                                   @"timestamp" : [NSNumber numberWithDouble:timestamp]
-                                                                               }];
+                                                           @"x" : [NSNumber numberWithDouble:x],
+                                                           @"y" : [NSNumber numberWithDouble:y],
+                                                           @"z" : [NSNumber numberWithDouble:z],
+                                                           @"timestamp" : [NSNumber numberWithDouble:timestamp]
+                                                       }];
      }];
 
 }

--- a/ios/Magnetometer.m
+++ b/ios/Magnetometer.m
@@ -91,7 +91,7 @@ RCT_EXPORT_METHOD(getData:(RCTResponseSenderBlock) cb) {
     double x = self->_motionManager.magnetometerData.magneticField.x;
     double y = self->_motionManager.magnetometerData.magneticField.y;
     double z = self->_motionManager.magnetometerData.magneticField.z;
-    double timestamp = [Utils sensorTimeToTimestampSince1970:self->_motionManager.magnetometerData.timestamp];
+    double timestamp = [Utils sensorTimestampToEpochMilliseconds:self->_motionManager.magnetometerData.timestamp];
 
     if (self->logLevel > 0) {
         NSLog(@"getData: %f, %f, %f, %f", x, y, z, timestamp);
@@ -120,7 +120,7 @@ RCT_EXPORT_METHOD(startUpdates) {
          double x = magnetometerData.magneticField.x;
          double y = magnetometerData.magneticField.y;
          double z = magnetometerData.magneticField.z;
-         double timestamp = [Utils sensorTimeToTimestampSince1970:magnetometerData.timestamp];
+         double timestamp = [Utils sensorTimestampToEpochMilliseconds:magnetometerData.timestamp];
 
          if (self->logLevel > 1) {
              NSLog(@"Updated magnetometer values: %f, %f, %f, %f", x, y, z, timestamp);

--- a/ios/RNSensors.xcodeproj/project.pbxproj
+++ b/ios/RNSensors.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8C5B457D24598D650018E8BA /* Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C5B457C24598D650018E8BA /* Utils.m */; };
 		B18A2800205ADE2700ED2038 /* Magnetometer.m in Sources */ = {isa = PBXBuildFile; fileRef = B18A27FF205ADE2700ED2038 /* Magnetometer.m */; };
 		E74E15A721AF4EA400E82D17 /* Barometer.m in Sources */ = {isa = PBXBuildFile; fileRef = E74E15A521AF4EA400E82D17 /* Barometer.m */; };
 		E7FCE1881E14639E005C5155 /* Gyroscope.m in Sources */ = {isa = PBXBuildFile; fileRef = E7FCE1871E14639E005C5155 /* Gyroscope.m */; };
@@ -27,6 +28,8 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libRNSensors.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNSensors.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8C5B457C24598D650018E8BA /* Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Utils.m; sourceTree = "<group>"; };
+		8C5B457F245992780018E8BA /* Utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Utils.h; sourceTree = "<group>"; };
 		B18A27FE205ADE2700ED2038 /* Magnetometer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Magnetometer.h; sourceTree = "<group>"; };
 		B18A27FF205ADE2700ED2038 /* Magnetometer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Magnetometer.m; sourceTree = "<group>"; };
 		E74E15A521AF4EA400E82D17 /* Barometer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Barometer.m; sourceTree = "<group>"; };
@@ -59,6 +62,8 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				8C5B457F245992780018E8BA /* Utils.h */,
+				8C5B457C24598D650018E8BA /* Utils.m */,
 				E74E15A621AF4EA400E82D17 /* Barometer.h */,
 				E74E15A521AF4EA400E82D17 /* Barometer.m */,
 				B18A27FE205ADE2700ED2038 /* Magnetometer.h */,
@@ -110,6 +115,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 58B511D21A9E6C8500147676;
@@ -130,6 +136,7 @@
 				E7FCE1881E14639E005C5155 /* Gyroscope.m in Sources */,
 				E7FCE18B1E150266005C5155 /* Accelerometer.m in Sources */,
 				B18A2800205ADE2700ED2038 /* Magnetometer.m in Sources */,
+				8C5B457D24598D650018E8BA /* Utils.m in Sources */,
 				E74E15A721AF4EA400E82D17 /* Barometer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Utils.h
+++ b/ios/Utils.h
@@ -2,6 +2,6 @@
 
 @interface Utils : NSObject
 
-- (double)sensorTimeToTimestampSince1970:(double) timestamp;
++ (double)sensorTimestampToEpochMilliseconds:(double) timestamp;
 
 @end

--- a/ios/Utils.h
+++ b/ios/Utils.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface Utils : NSObject
+
+- (double)sensorTimeToTimestampSince1970:(double) timestamp;
+
+@end

--- a/ios/Utils.m
+++ b/ios/Utils.m
@@ -2,9 +2,8 @@
 
 @implementation Utils
 
-- (double)sensorTimeToTimestampSince1970:(double) timestamp {
-    NSTimeInterval uptime = [[NSProcessInfo processInfo] systemUptime];
-    return ((NSTimeIntervalSince1970 + uptime) + (timestamp - uptime)) * 1000;
++ (double)sensorTimestampToEpochMilliseconds:(NSTimeInterval) timestamp {
+    return floor(([[NSDate date] timeIntervalSince1970] + (timestamp - [[NSProcessInfo processInfo] systemUptime])) * 1000);
 }
 
 @end

--- a/ios/Utils.m
+++ b/ios/Utils.m
@@ -1,0 +1,10 @@
+#import "Utils.h"
+
+@implementation Utils
+
+- (double)sensorTimeToTimestampSince1970:(double) timestamp {
+    NSTimeInterval uptime = [[NSProcessInfo processInfo] systemUptime];
+    return ((NSTimeIntervalSince1970 + uptime) + (timestamp - uptime)) * 1000;
+}
+
+@end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sensors",
-  "version": "5.0.0-rc4",
+  "version": "5.4.2",
   "description": "A developer friendly approach for sensors in react-native",
   "scripts": {
     "contributor:add": "all-contributors add",

--- a/src/sensors.js
+++ b/src/sensors.js
@@ -24,7 +24,7 @@ const nativeApis = new Map([
   ["barometer", BarNative]
 ]);
 
-const eventEmitterSubsciption = new Map([
+const eventEmitterSubscription = new Map([
   ["accelerometer", null],
   ["gyroscope", null],
   ["magnetometer", null],
@@ -37,8 +37,8 @@ function createSensorObservable(sensorType) {
 
     this.unsubscribeCallback = () => {
       if (!this.isSensorAvailable) return;
-      if (eventEmitterSubsciption.get(sensorType))
-        eventEmitterSubsciption.get(sensorType).remove();
+      if (eventEmitterSubscription.get(sensorType))
+        eventEmitterSubscription.get(sensorType).remove();
       // stop the sensor
       RNSensors.stop(sensorType);
     };
@@ -49,7 +49,7 @@ function createSensorObservable(sensorType) {
 
         const emitter = new NativeEventEmitter(nativeApis.get(sensorType));
 
-        eventEmitterSubsciption.set(
+        eventEmitterSubscription.set(
           sensorType,
           emitter.addListener(listenerKeys.get(sensorType), data => {
             observer.next(data);


### PR DESCRIPTION
Currently the sensors timestamp in Android is the Current milliseconds and on iOS is the sensor timestamp that returns a timeinterval from the phone start.

This pull request will generalize this as an Epoch milliseconds timestamp (calculated from the sensors timestamps) 

Fixes #78

Additionally I did some spellcheck fixes, exposed the sensor types to be able to be used directly from the apps, and added timestamp to the Barometer

