### PR TITLE
fix(typings): timestamp to number

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,12 +19,12 @@ declare module "react-native-sensors" {
     x: number;
     y: number;
     z: number;
-    timestamp: string;
+    timestamp: number;
   }
 
   export interface BarometerData {
     pressure: number;
-    timestamp: string;
+    timestamp: number;
   }
 
   type SensorsBase = {


### PR DESCRIPTION
The field `timestamp` in the interface `SensorData` and `BarometerData` is typed wrong - the provided value is `number` but it's typed as a `string`.