### PR TITLE
fix: xcode 12 compatibility

### DIFF
--- a/RNSensors.podspec
+++ b/RNSensors.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.platform            = :ios, "7.0"
   s.source_files        = "ios/*.{h,m}"
   s.preserve_paths      = "*.js"
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
According to https://github.com/facebook/react-native/issues/29633#issuecomment-694187116 - "React pod is in fact really only an umbrella dependency for pure JS applications to depend on, whereas the native APIs that these libraries rely on actually reside in the React-Core pod." and it will fail to build on Xcode12. This PR updates the dependency from `React` to `React-Core`.