### PR TITLE
Add Jest mock implementation

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -11,3 +11,13 @@ title: FAQ
 ## The Accelerometer always shows a positive value
 
 The Accelerometer will always show a positive z value, because this includes the gravitation from earth.
+
+## Testing with Jest
+
+The library provides a mock implementation for Jest via the following line:
+
+```js
+jest.mock('react-native-sensors', () => require('react-native-sensors/mock'))
+```
+
+If not done already, create a file named `jestSetup.js` for instance, provide its path to Jest configuration [`setupFiles`](https://jestjs.io/docs/en/configuration.html#setupfiles-array) entry and add the aforementioned line to that setup file.

--- a/mock.js
+++ b/mock.js
@@ -1,0 +1,33 @@
+/**
+ * Library mock for test runners. e.g.:
+ *
+ * ```js
+ * jest.mock('react-native-sensors', () => require('react-native-sensors/mock'));
+ * ```
+ */
+
+const sensorMock = (observerValue) => ({
+  subscribe: (observer) => {
+    observer(observerValue || { x: 0, y: 0, z: 0, timestamp: 0 })
+    return ({ unsubscribe: jest.fn() })
+  },
+})
+
+const rnSensors = {
+  SensorTypes: {
+    accelerometer: 'accelerometer',
+    gyroscope: 'gyroscope',
+    magnetometer: 'magnetometer',
+    barometer: 'barometer',
+  },
+
+  accelerometer: sensorMock(),
+  gyroscope: sensorMock(),
+  magnetometer: sensorMock(),
+  barometer: sensorMock({ pressure: 0 }),
+
+  setLogLevelForType: jest.fn(),
+  setUpdateIntervalForType: jest.fn(),
+}
+
+module.exports = rnSensors


### PR DESCRIPTION
This PR adds Jest mocks to the library as discussed in #317.

If needed, even a sensor `subscribe()` observer can be tested as such:

```js
const { accelerometer } = jest.requireMock('react-native-sensors')

it('called our observer', () => {
  const observer = jest.fn()
  accelerometer.subscribe(observer)
  expect(observer).toHaveBeenCalledTimes(1)
  expect(observer).toHaveBeenCalledWith({ x: 0, y: 0, z: 0, timestamp: 0 })
})
```

You'll notice that I've set up all the values returned by the observer to `0` as that was the easiest thing to do right now. Would there be a need to test specific observer values, this approach would have to be modified.

I tested these changes with the app I'm working on right now by simply adding the following to my jest [`setupFiles`](https://jestjs.io/docs/en/configuration.html#setupfiles-array) file:
```js
jest.mock('react-native-sensors', () => require('react-native-sensors/mock'))
```

This is pretty much the only thing people would have to write to have everything working, plus methods like [`jest.requireActual()`](https://jestjs.io/docs/en/jest-object#jestrequireactualmodulename) or [`jest.requireMock()`](https://jestjs.io/docs/en/jest-object#jestrequiremockmodulename) behaving as expected.

Now, I'm just wondering whether to mention this in the doc website or add a few lines in the README here on GitHub. Let me know what you'd prefer!