### PR TITLE
Add missing setLogLevelForType TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,8 @@ declare module "react-native-sensors" {
   export const SensorTypes: Sensors;
 
   export const setUpdateIntervalForType: (type: keyof Sensors, updateInterval: number) => void;
+  
+  export const setLogLevelForType: (type: keyof Sensors, logLevel: 0 | 1 | 2) => void;
 
   export interface SensorData {
     x: number;


### PR DESCRIPTION
Hi! setLogLevelForType () was forgotten in 390b561 that updated the TS definitions, adding it with this PR.