### PR TITLE
Correct instances of missed renaming from Utils to RNSensorsUtils

### DIFF
--- a/ios/RNSensorsAccelerometer.m
+++ b/ios/RNSensorsAccelerometer.m
@@ -90,7 +90,7 @@ RCT_EXPORT_METHOD(getData:(RCTResponseSenderBlock) cb) {
     double x = self->_motionManager.accelerometerData.acceleration.x;
     double y = self->_motionManager.accelerometerData.acceleration.y;
     double z = self->_motionManager.accelerometerData.acceleration.z;
-    double timestamp = [Utils sensorTimestampToEpochMilliseconds:self->_motionManager.accelerometerData.timestamp];
+    double timestamp = [RNSensorsUtils sensorTimestampToEpochMilliseconds:self->_motionManager.accelerometerData.timestamp];
 
     if (self->logLevel > 0) {
         NSLog(@"getData: %f, %f, %f, %f", x, y, z, timestamp);
@@ -119,7 +119,7 @@ RCT_EXPORT_METHOD(startUpdates) {
          double x = accelerometerData.acceleration.x;
          double y = accelerometerData.acceleration.y;
          double z = accelerometerData.acceleration.z;
-         double timestamp = [Utils sensorTimestampToEpochMilliseconds:accelerometerData.timestamp];
+         double timestamp = [RNSensorsUtils sensorTimestampToEpochMilliseconds:accelerometerData.timestamp];
 
          if (self->logLevel > 1) {
              NSLog(@"Updated accelerometer values: %f, %f, %f, %f", x, y, z, timestamp);

--- a/ios/RNSensorsBarometer.m
+++ b/ios/RNSensorsBarometer.m
@@ -75,12 +75,12 @@ RCT_EXPORT_METHOD(getData:(RCTResponseSenderBlock) cb) {
     CMAltitudeData * _Nullable altitudeData = self->_altimeter;
     if (altitudeData) {
         if (self->logLevel > 0) {
-            NSLog(@"getData: %f, %f, %f", altitudeData.pressure.doubleValue, altitudeData.timestamp, [Utils sensorTimestampToEpochMilliseconds:altitudeData.timestamp]);
+            NSLog(@"getData: %f, %f, %f", altitudeData.pressure.doubleValue, altitudeData.timestamp, [RNSensorsUtils sensorTimestampToEpochMilliseconds:altitudeData.timestamp]);
         }
 
         cb(@[[NSNull null], @{
                 @"pressure" : @(altitudeData.pressure.doubleValue * 10.0),
-                @"timestamp" : [NSNumber numberWithDouble:[Utils sensorTimestampToEpochMilliseconds:altitudeData.timestamp]]
+                @"timestamp" : [NSNumber numberWithDouble:[RNSensorsUtils sensorTimestampToEpochMilliseconds:altitudeData.timestamp]]
             }]
            );
     }
@@ -102,12 +102,12 @@ RCT_EXPORT_METHOD(startUpdates) {
 
         if (altitudeData) {
             if (self->logLevel > 1) {
-                NSLog(@"Updated altitue value: %f, %f, %f", altitudeData.pressure.doubleValue, altitudeData.timestamp, [Utils sensorTimestampToEpochMilliseconds:altitudeData.timestamp]);
+                NSLog(@"Updated altitue value: %f, %f, %f", altitudeData.pressure.doubleValue, altitudeData.timestamp, [RNSensorsUtils sensorTimestampToEpochMilliseconds:altitudeData.timestamp]);
             }
 
             [self sendEventWithName:@"Barometer" body:@{
                 @"pressure" : @(altitudeData.pressure.doubleValue * 10.0),
-                @"timestamp" : [NSNumber numberWithDouble:[Utils sensorTimestampToEpochMilliseconds:altitudeData.timestamp]]
+                @"timestamp" : [NSNumber numberWithDouble:[RNSensorsUtils sensorTimestampToEpochMilliseconds:altitudeData.timestamp]]
             }];
         }
 

--- a/ios/RNSensorsGyroscope.m
+++ b/ios/RNSensorsGyroscope.m
@@ -88,7 +88,7 @@ RCT_EXPORT_METHOD(getData:(RCTResponseSenderBlock) cb) {
     double x = self->_motionManager.gyroData.rotationRate.x;
     double y = self->_motionManager.gyroData.rotationRate.y;
     double z = self->_motionManager.gyroData.rotationRate.z;
-    double timestamp = [Utils sensorTimestampToEpochMilliseconds:self->_motionManager.gyroData.timestamp];
+    double timestamp = [RNSensorsUtils sensorTimestampToEpochMilliseconds:self->_motionManager.gyroData.timestamp];
 
     if (self->logLevel > 0) {
         NSLog(@"getData: %f, %f, %f, %f", x, y, z, timestamp);
@@ -117,7 +117,7 @@ RCT_EXPORT_METHOD(startUpdates) {
          double x = gyroData.rotationRate.x;
          double y = gyroData.rotationRate.y;
          double z = gyroData.rotationRate.z;
-         double timestamp = [Utils sensorTimestampToEpochMilliseconds:gyroData.timestamp];
+         double timestamp = [RNSensorsUtils sensorTimestampToEpochMilliseconds:gyroData.timestamp];
 
          if (self->logLevel > 1) {
              NSLog(@"Updated gyro values: %f, %f, %f, %f", x, y, z, timestamp);

--- a/ios/RNSensorsMagnetometer.m
+++ b/ios/RNSensorsMagnetometer.m
@@ -91,7 +91,7 @@ RCT_EXPORT_METHOD(getData:(RCTResponseSenderBlock) cb) {
     double x = self->_motionManager.magnetometerData.magneticField.x;
     double y = self->_motionManager.magnetometerData.magneticField.y;
     double z = self->_motionManager.magnetometerData.magneticField.z;
-    double timestamp = [Utils sensorTimestampToEpochMilliseconds:self->_motionManager.magnetometerData.timestamp];
+    double timestamp = [RNSensorsUtils sensorTimestampToEpochMilliseconds:self->_motionManager.magnetometerData.timestamp];
 
     if (self->logLevel > 0) {
         NSLog(@"getData: %f, %f, %f, %f", x, y, z, timestamp);
@@ -120,7 +120,7 @@ RCT_EXPORT_METHOD(startUpdates) {
          double x = magnetometerData.magneticField.x;
          double y = magnetometerData.magneticField.y;
          double z = magnetometerData.magneticField.z;
-         double timestamp = [Utils sensorTimestampToEpochMilliseconds:magnetometerData.timestamp];
+         double timestamp = [RNSensorsUtils sensorTimestampToEpochMilliseconds:magnetometerData.timestamp];
 
          if (self->logLevel > 1) {
              NSLog(@"Updated magnetometer values: %f, %f, %f, %f", x, y, z, timestamp);

--- a/ios/RNSensorsOrientation.m
+++ b/ios/RNSensorsOrientation.m
@@ -99,7 +99,7 @@ RCT_EXPORT_METHOD(getData:(RCTResponseSenderBlock) cb) {
     double roll = attitude.roll;
     double yaw = attitude.yaw;
 
-    double timestamp = [Utils sensorTimestampToEpochMilliseconds:self->_motionManager.deviceMotion.timestamp];
+    double timestamp = [RNSensorsUtils sensorTimestampToEpochMilliseconds:self->_motionManager.deviceMotion.timestamp];
 
     if (self->logLevel > 0) {
         NSLog(@"getData pitch/roll/yaw: %f, %f, %f, %f", pitch, roll, yaw, timestamp);
@@ -142,7 +142,7 @@ RCT_EXPORT_METHOD(startUpdates) {
          double roll = attitude.roll;
          double yaw = attitude.yaw;
 
-         double timestamp = [Utils sensorTimestampToEpochMilliseconds:deviceMotion.timestamp];
+         double timestamp = [RNSensorsUtils sensorTimestampToEpochMilliseconds:deviceMotion.timestamp];
 
          if (self->logLevel > 1) {
              NSLog(@"Updated device motion pitch/roll/yaw: %f, %f, %f, %f", pitch, roll, yaw, timestamp);


### PR DESCRIPTION
[v7.2.1-rc.1](https://github.com/react-native-sensors/react-native-sensors/releases/tag/v7.2.1-rc.1) fails to build because of some missed instances of renaming Utils to RNSensorsUtils.