### PR TITLE
Prefix Android NativeModules with RNSensors

### DIFF
--- a/android/src/main/java/com/sensors/RNSensorsPackage.java
+++ b/android/src/main/java/com/sensors/RNSensorsPackage.java
@@ -15,11 +15,11 @@ import com.facebook.react.bridge.JavaScriptModule;
 public class RNSensorsPackage implements ReactPackage {
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
       return Arrays.<NativeModule>asList(
-        new RNSensor(reactContext, "Gyroscope", Sensor.TYPE_GYROSCOPE),
-        new RNSensor(reactContext, "Accelerometer", Sensor.TYPE_ACCELEROMETER),
-        new RNSensor(reactContext, "Magnetometer", Sensor.TYPE_MAGNETIC_FIELD),
-        new RNSensor(reactContext, "Barometer", Sensor.TYPE_PRESSURE),
-        new RNSensor(reactContext, "Orientation", Sensor.TYPE_ROTATION_VECTOR)
+        new RNSensor(reactContext, "RNSensorsGyroscope", Sensor.TYPE_GYROSCOPE),
+        new RNSensor(reactContext, "RNSensorsAccelerometer", Sensor.TYPE_ACCELEROMETER),
+        new RNSensor(reactContext, "RNSensorsMagnetometer", Sensor.TYPE_MAGNETIC_FIELD),
+        new RNSensor(reactContext, "RNSensorsBarometer", Sensor.TYPE_PRESSURE),
+        new RNSensor(reactContext, "RNSensorsOrientation", Sensor.TYPE_ROTATION_VECTOR)
       );
     }
 

--- a/src/sensors.js
+++ b/src/sensors.js
@@ -4,11 +4,11 @@ import { publish, refCount } from "rxjs/operators";
 import * as RNSensors from "./rnsensors";
 
 const {
-  Gyroscope: GyroNative,
-  Accelerometer: AccNative,
-  Magnetometer: MagnNative,
-  Barometer: BarNative,
-  Orientation: OrientNative,
+  RNSensorsGyroscope: GyroNative,
+  RNSensorsAccelerometer: AccNative,
+  RNSensorsMagnetometer: MagnNative,
+  RNSensorsBarometer: BarNative,
+  RNSensorsOrientation: OrientNative,
 } = NativeModules;
 
 const listenerKeys = new Map([


### PR DESCRIPTION
Closes #381 

Adds a prefix "RNSensors" to the Native Modules on Android. The module name changing from "Orientation" resolves #381 .