### PR TITLE
iOS orientation sensor fix

### DIFF
--- a/ios/RNSensorsOrientation.m
+++ b/ios/RNSensorsOrientation.m
@@ -127,9 +127,8 @@ RCT_EXPORT_METHOD(startUpdates) {
     [self->_motionManager setShowsDeviceMovementDisplay:YES];
 
     /* Receive the orientation data on this block */
-    [self->_motionManager startDeviceMotionUpdatesUsingReferenceFrame:CMAttitudeReferenceFrameXTrueNorthZVertical
-                                               toQueue:[NSOperationQueue mainQueue]
-                                               withHandler:^(CMDeviceMotion *deviceMotion, NSError *error)
+		NSOperationQueue *queue = [[NSOperationQueue alloc] init];
+    [self->_motionManager startDeviceMotionUpdatesToQueue:queue withHandler:^(CMDeviceMotion *deviceMotion, NSError *error)
      {
          CMAttitude *attitude = deviceMotion.attitude;
          


### PR DESCRIPTION
Hello!
The orientation sensor did not work on the iOS device. I fixed it

When subscribing, we received only one response with the following value:
`{"pitch": 0, "qw": 0, "qx": 0, "qy": 0, "qz": 0, "roll": 0, "timestamp": 1640014079986, "yaw": 0}`