### PR TITLE
Convert Android's accelerometer and gravity sensors to use g unit

### DIFF
--- a/android/src/main/java/com/sensors/RNSensor.java
+++ b/android/src/main/java/com/sensors/RNSensor.java
@@ -21,6 +21,7 @@ public class RNSensor extends ReactContextBaseJavaModule implements SensorEventL
   private final ReactApplicationContext reactContext;
   private final SensorManager sensorManager;
   private final Sensor sensor;
+  private final double gravityValue = 9.80665; // m/s^2
   private double lastReading = (double) System.currentTimeMillis();
   private int interval;
   private Arguments arguments;
@@ -114,6 +115,11 @@ public class RNSensor extends ReactContextBaseJavaModule implements SensorEventL
       {
         case Sensor.TYPE_ACCELEROMETER:
         case Sensor.TYPE_GRAVITY:
+          map.putDouble("x", sensorEvent.values[0] / gravityValue);
+          map.putDouble("y", sensorEvent.values[1] / gravityValue);
+          map.putDouble("z", sensorEvent.values[2] / gravityValue);
+          break;
+
         case Sensor.TYPE_GYROSCOPE:
         case Sensor.TYPE_MAGNETIC_FIELD:
           map.putDouble("x", sensorEvent.values[0]);

--- a/android/src/main/java/com/sensors/RNSensor.java
+++ b/android/src/main/java/com/sensors/RNSensor.java
@@ -21,7 +21,7 @@ public class RNSensor extends ReactContextBaseJavaModule implements SensorEventL
   private final ReactApplicationContext reactContext;
   private final SensorManager sensorManager;
   private final Sensor sensor;
-  private final double gravityValue = 9.80665; // m/s^2
+  private final double gravityValue = -9.80665; // m/s^2
   private double lastReading = (double) System.currentTimeMillis();
   private int interval;
   private Arguments arguments;


### PR DESCRIPTION
This PR addresses #355 

It seems that it's more common to use the "g" unit for accelerometer data rather than Android's m/s².

However, if this PR is merged as is, even though there are no syntactical changes, the values coming from both Accelerometer and Gravity sensors would change for Android apps (eg. a value of 9.81 will, after this is merged, become 1). So maybe this is enough for a major bump?

Alternatively, we could add a _flag_ to allow the user to choose between g unit and "platform default". The default value of that flag would be "platform default", therefore the change wouldn't be so significant. I'm glad to implement that flag in the same PR. 

What's your opinion on it? 