### PR TITLE
Fix RN warnings about EventListeners

### DIFF
--- a/android/src/main/java/com/sensors/RNSensor.java
+++ b/android/src/main/java/com/sensors/RNSensor.java
@@ -31,6 +31,8 @@ public class RNSensor extends ReactContextBaseJavaModule implements SensorEventL
   private float[] orientation = new float[3];
   private float[] quaternion = new float[4];
 
+  private Boolean isBeingObserved = false;
+
   public RNSensor(ReactApplicationContext reactContext, String sensorName, int sensorType) {
     super(reactContext);
     this.reactContext = reactContext;
@@ -94,6 +96,10 @@ public class RNSensor extends ReactContextBaseJavaModule implements SensorEventL
 
   @Override
   public void onSensorChanged(SensorEvent sensorEvent) {
+    if(!isBeingObserved) {
+      return; // avoid all the computation if there are no observers
+    }
+
     int currentType = sensorEvent.sensor.getType();
     if(currentType != this.sensorType) { // not for the current Sensor
       return;
@@ -149,11 +155,18 @@ public class RNSensor extends ReactContextBaseJavaModule implements SensorEventL
   public void onAccuracyChanged(Sensor sensor, int accuracy) {
   }
 
+  // this is called by RN when the first listener is registered
+  // not implementing this method will cause a warning on RN 0.65 onwards
   @ReactMethod
   public void addListener(String eventName) {
+    isBeingObserved = true;
   }
 
+  // this is called by RN when the last listener is deregistered
+  // not implementing this method will cause a warning on RN 0.65 onwards
   @ReactMethod
   public void removeListeners(Integer count) {
+    isBeingObserved = false;
+    stopUpdates(); // maybe only calling `stopUpdates()` is enough
   }
 }

--- a/android/src/main/java/com/sensors/RNSensor.java
+++ b/android/src/main/java/com/sensors/RNSensor.java
@@ -148,4 +148,12 @@ public class RNSensor extends ReactContextBaseJavaModule implements SensorEventL
   @Override
   public void onAccuracyChanged(Sensor sensor, int accuracy) {
   }
+
+  @ReactMethod
+  public void addListener(String eventName) {
+  }
+
+  @ReactMethod
+  public void removeListeners(Integer count) {
+  }
 }


### PR DESCRIPTION
On Android, when running RN >= 0.65, we keep getting warnings:
```
'`new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.'
```
Introduced in [this commit]('`new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.')

This PR addresses this issue. 