### PR TITLE
Do not crash on missing sensors

### DIFF
--- a/android/src/main/java/com/sensors/RNSensor.java
+++ b/android/src/main/java/com/sensors/RNSensor.java
@@ -46,11 +46,9 @@ public class RNSensor extends ReactContextBaseJavaModule implements SensorEventL
   @ReactMethod
   public void isAvailable(Promise promise) {
     if (this.sensor == null) {
-      // No sensor found, throw error
-      promise.reject(new RuntimeException("No " + this.sensorName + " found"));
-      return;
+      promise.resolve(false);
     }
-    promise.resolve(null);
+    promise.resolve(true);
   }
 
   @ReactMethod

--- a/ios/RNSensorsAccelerometer.m
+++ b/ios/RNSensorsAccelerometer.m
@@ -49,12 +49,12 @@ RCT_REMAP_METHOD(isAvailable,
         {
             resolve(@YES);
         } else {
-            reject(@"-1", @"Accelerometer is not active", nil);
+            resolve(@NO);
         }
     }
     else
     {
-        reject(@"-1", @"Accelerometer is not available", nil);
+        resolve(@NO);
     }
 }
 

--- a/ios/RNSensorsBarometer.m
+++ b/ios/RNSensorsBarometer.m
@@ -50,7 +50,7 @@ RCT_REMAP_METHOD(isAvailable,
     }
     else
     {
-        reject(@"-1", @"Barometer is not available", nil);
+        resolve(@NO);
     }
 }
 

--- a/ios/RNSensorsGravity.m
+++ b/ios/RNSensorsGravity.m
@@ -50,12 +50,12 @@ RCT_REMAP_METHOD(isAvailable,
         {
             resolve(@YES);
         } else {
-            reject(@"-1", @"Gravity is not active", nil);
+            resolve(@NO);
         }
     }
     else
     {
-        reject(@"-1", @"Gravity is not available", nil);
+        resolve(@NO);
     }
 }
 

--- a/ios/RNSensorsGyroscope.m
+++ b/ios/RNSensorsGyroscope.m
@@ -47,12 +47,12 @@ RCT_REMAP_METHOD(isAvailable,
         {
             resolve(@YES);
         } else {
-            reject(@"-1", @"Gyroscope is not active", nil);
+            resolve(@NO);
         }
     }
     else
     {
-        reject(@"-1", @"Gyroscope is not available", nil);
+        resolve(@NO);
     }
 }
 

--- a/ios/RNSensorsMagnetometer.m
+++ b/ios/RNSensorsMagnetometer.m
@@ -50,12 +50,12 @@ RCT_REMAP_METHOD(isAvailable,
         {
             resolve(@YES);
         } else {
-            reject(@"-1", @"Magnetometer is not active", nil);
+            resolve(@NO);
         }
     }
     else
     {
-        reject(@"-1", @"Magnetometer is not available", nil);
+        resolve(@NO);
     }
 }
 

--- a/ios/RNSensorsOrientation.m
+++ b/ios/RNSensorsOrientation.m
@@ -50,12 +50,12 @@ RCT_REMAP_METHOD(isAvailable,
         {
             resolve(@YES);
         } else {
-            reject(@"-1", @"Orientation is not active", nil);
+            resolve(@NO);
         }
     }
     else
     {
-        reject(@"-1", @"Orientation is not available", nil);
+        resolve(@NO);
     }
 }
 

--- a/src/sensors.js
+++ b/src/sensors.js
@@ -51,8 +51,8 @@ function createSensorObservable(sensorType) {
     };
 
     RNSensors.isAvailable(sensorType).then(
-      () => {
-        this.isSensorAvailable = true;
+      (available) => {
+        this.isSensorAvailable = available;
 
         const emitter = new NativeEventEmitter(nativeApis.get(sensorType));
 
@@ -67,7 +67,7 @@ function createSensorObservable(sensorType) {
         RNSensors.start(sensorType);
       },
       () => {
-        observer.error(`Sensor ${sensorType} is not available`);
+        this.isSensorAvailable = false;
       }
     );
 


### PR DESCRIPTION
Importing sensors on older devices that misses that physical  sensors crashes. IMO it's better to handle this without crashing. The proposed diff is applied from thepatch we use to fix this issue in our own app, we could maybe find a more suitable solution if we want to go this way.

What do you think?