### PR TITLE
Add support for object observer form of subscriber in mock.js

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -8,7 +8,12 @@
 
 const sensorMock = (observerValue) => ({
   subscribe: (observer) => {
-    observer(observerValue || { x: 0, y: 0, z: 0, timestamp: 0 })
+    if ('next' in observer) {
+      observer.next(observerValue || { x: 0, y: 0, z: 0, timestamp: 0 })
+    } else {
+      observer(observerValue || { x: 0, y: 0, z: 0, timestamp: 0 })
+    }
+
     return ({ unsubscribe: jest.fn() })
   },
 })


### PR DESCRIPTION
- Currently the mock will crash if using the object form of the subscriber (`{ next: (val) => {} }`), it currently only expects a basic subscriber or the deprecated form.
- Add support for this form of the subscriber.