### PR TITLE
Replace deprecated jcenter() with mavenCentral()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,6 @@ def safeExtGet(prop, fallback) {
 repositories {
   mavenCentral()
   google()
-  jcenter()
 }
 
 buildscript {

--- a/examples/GryoscopeImage/android/build.gradle
+++ b/examples/GryoscopeImage/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 allprojects {
     repositories {
         mavenLocal()
-        jcenter()
+        mavenCentral()
         google()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm

--- a/examples/KeepTheBallGame/android/build.gradle
+++ b/examples/KeepTheBallGame/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 allprojects {
     repositories {
         mavenLocal()
-        jcenter()
+        mavenCentral()
         google()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm


### PR DESCRIPTION
JCenter has been deprecated and shut down. This change replaces all jcenter() repository references with mavenCentral() to fix build failures.

Changes:
- Replace jcenter() with mavenCentral() in main android/build.gradle
- Update example apps (GryoscopeImage and KeepTheBallGame) build.gradle files